### PR TITLE
Fix sorting order for Babel labels

### DIFF
--- a/lib/src/gobabel_labels_extractor_controller.dart
+++ b/lib/src/gobabel_labels_extractor_controller.dart
@@ -158,11 +158,9 @@ class GobabelStringExtractorController {
     // Sort the entries by startIndex. The first should be the biggest index,
     // the last should be the smallest index
     allHardcodedStrings.forEach((key, value) {
-      value.sort((a, b) {
-        final aIndex = a.fileStartIndex;
-        final bIndex = b.fileStartIndex;
-        return aIndex.compareTo(bIndex); // Descending order
-      });
+      value.sort(
+        (a, b) => b.fileStartIndex.compareTo(a.fileStartIndex),
+      );
     });
 
     if (generateLogs) {

--- a/lib/src/usecases/map_babel_labels.dart
+++ b/lib/src/usecases/map_babel_labels.dart
@@ -44,12 +44,8 @@ class MapBabelLabelsUsecaseImpl implements IMapBabelLabelsUsecase {
     final Set<VariableName> variableNames = {};
     final Set<String> implementationParameters = {};
 
-    // Sort children by parentStartIndex in increment order (smallest first, biggest last)
-    children.sort((a, b) {
-      final aIndex = _getStartIndex(a);
-      final bIndex = _getEndIndex(b);
-      return aIndex.compareTo(bIndex); // Descending order
-    });
+    // Sort children by parentStartIndex in descending order (biggest first, smallest last)
+    children.sort((a, b) => _getStartIndex(b).compareTo(_getStartIndex(a)));
 
     int index = 0;
     for (final child in children) {
@@ -121,12 +117,8 @@ class MapBabelLabelsUsecaseImpl implements IMapBabelLabelsUsecase {
     final Set<VariableName> variableNames = {};
     final Set<String> implementationParameters = {};
 
-    // Sort children by parentStartIndex in increment order (smallest first, biggest last)
-    children.sort((a, b) {
-      final aIndex = _getStartIndex(a);
-      final bIndex = _getEndIndex(b);
-      return aIndex.compareTo(bIndex); // Descending order
-    });
+    // Sort children by parentStartIndex in descending order (biggest first, smallest last)
+    children.sort((a, b) => _getStartIndex(b).compareTo(_getStartIndex(a)));
 
     int index = 0;
     for (final child in children) {
@@ -200,11 +192,9 @@ class MapBabelLabelsUsecaseImpl implements IMapBabelLabelsUsecase {
     String content = entity.content;
 
     // Sort children by parentStartIndex in descending order (biggest first, smallest last)
-    processedChildren.sort((a, b) {
-      final aIndex = _getStartIndex(a);
-      final bIndex = _getEndIndex(b);
-      return bIndex.compareTo(aIndex); // Descending order
-    });
+    processedChildren.sort(
+      (a, b) => _getStartIndex(b).compareTo(_getStartIndex(a)),
+    );
 
     for (final child in processedChildren) {
       child.mapOrNull(


### PR DESCRIPTION
## Summary
- fix sort order in gobabel labels extractor controller
- consistently compare child start indexes when sorting Babel label structures

## Testing
- `dart test` *(fails: dart not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843c0d860c08331bce0243bc5e80da7